### PR TITLE
Improve package.json and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,33 @@
 
 # bonsai.css
 
-**A complete Utility First CSS Framework for less than 45kb (8kB Gzipped)**
+**A complete Utility First CSS Framework for less than 45 KB (8 KB Gzipped)**
 
-Bonsai CSS is a super lightweight, fully responsive, utlity first framework. All you need to build beautifully crafted web interfaces with ease.
+Bonsai CSS is a super lightweight, fully responsive, utility first framework. All you need to build beautifully crafted web interfaces with ease.
+
+### Setup for development
+
+Install the dependencies with npm first:
+
+```bash
+npm i
+```
+
+### Building
+
+To build new Bonsai files (in the dist folder), run:
+
+```bash
+npm run build
+```
+
+### Developing
+
+To automatically build new versions of Bonsai during development, run:
+
+```
+npm run watch
+```
 
 ## Documentation
 

--- a/index.js
+++ b/index.js
@@ -1,2 +1,0 @@
-const gulpfile = require('./gulpfile')
-gulpfile.watch()

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.1.0",
   "description": "Largely classless, blazing fast and super light-weight. Bonsai, a base CSS framework for modern browsers",
   "main": "dist/bansai.min.css",
+  "scripts": {
+    "build": "gulp build",
+    "watch": "gulp watch"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/bonsaicss/bonsai.css.git"


### PR DESCRIPTION
Removed the index.js, in favor of the scripts section in the package.json (the default way).

Added some build and development instructions to the README.md and meanwhile fixed some typos.
