### PR TITLE
Remove overflow:hidden from .accent

### DIFF
--- a/src/base/_utilities.css
+++ b/src/base/_utilities.css
@@ -71,7 +71,6 @@
   border: var(--accent-border, 0);
   border-radius: var(--border-radius, 0);
   box-shadow: var(--accent-shadow, none);
-  overflow: hidden;
 
   &.primary,
   &.secondary,


### PR DESCRIPTION
Removes overflow: hidden from .accent class.

Related issue: #31