### PR TITLE
Add styling for invalid and valid (HTML5 form validation)

### DIFF
--- a/src/base/_forms.css
+++ b/src/base/_forms.css
@@ -140,6 +140,18 @@ textarea:focus {
   box-shadow: 0 0 0 3px var(--focus);
 }
 
+input:valid,
+select:valid,
+textarea:valid {
+  border-color: var(--green);
+}
+
+input:invalid,
+select:invalid,
+textarea:invalid {
+  border-color: var(--red);
+}
+
 input[type="checkbox"],
 input[type="radio"] {
   position: relative;


### PR DESCRIPTION
This adds some basic styling for :valid or :invalid input elements.

Maybe we should add two variables to the :root too? 

:root {
  --valid: var(--green);
  --invalid: var(--red);
}

Or even more generic variables, something like --success or --error (and maybe --warning, --info), which could also be used for other things.

What do you think?