### PR TITLE
Add .outline class for elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,6 +247,17 @@
         </div>
 
         <div>
+          <p style="--mb:0">Buttons with Outline</p>
+          <button class="green outline">Green</button>
+          <button class="orange outline">Orange</button>
+          <button class="red outline">Red</button>
+          <button class="white outline">White</button>
+          <button class="grey outline">Grey</button>
+          <button class="black outline" outline>Black</button>
+          <button class="transparent outline">Transparent</button>
+        </div>
+
+        <div>
           <p style="--mb:0">Button Groups (Vertical)</p>
             <span class="group vertical">
               <button>Button</button>

--- a/src/base/_forms.css
+++ b/src/base/_forms.css
@@ -59,7 +59,7 @@ details > summary,
   border: 2px solid var(--element-bg);
 }
 
-.outline:hover {
+.outline:hover, .outline:focus, .outline:active {
   box-shadow: none;
   color: var(--btn-c, var(--white));
   background-color: var(--element-bg, var(--primary));

--- a/src/base/_forms.css
+++ b/src/base/_forms.css
@@ -52,6 +52,19 @@ details > summary,
   appearance: none;
 }
 
+.outline {
+  background: transparent;
+  box-shadow: none;
+  color: var(--form-text);
+  border: 2px solid var(--element-bg);
+}
+
+.outline:hover {
+  box-shadow: none;
+  color: var(--btn-c, var(--white));
+  background-color: var(--element-bg, var(--primary));
+}
+
 details {
   margin: 0.5rem 0;
   background-color: var(--background);


### PR DESCRIPTION
Add a `.outline` class for Buttons, Tags.. Sets the primary class as border and background to transparent.

![2020-11-26_11-11-1606386663](https://user-images.githubusercontent.com/897638/100340083-f5507980-2fda-11eb-8c0b-c06bdcd827ce.png)

Usage:

```html
<button class="green outline">Green</button>
```
