### PR TITLE
Correct html background variable

### DIFF
--- a/src/base/_body.css
+++ b/src/base/_body.css
@@ -11,7 +11,7 @@ html {
   font-weight: 400;
 
   color: var(--text-main);
-  background: var(--background-body);
+  background: var(--background);
 
   text-size-adjust: 100%;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
Fixes #61 

Corrects the CSS variable name for the `html` background property.