### PR TITLE
Change .outline text color to --element-bg

### DIFF
--- a/src/base/_forms.css
+++ b/src/base/_forms.css
@@ -55,7 +55,7 @@ details > summary,
 .outline {
   background: transparent;
   box-shadow: none;
-  color: var(--form-text);
+  color: var(--element-bg);
   border: 2px solid var(--element-bg);
 }
 


### PR DESCRIPTION
Just a small PR changing the .outline text color to match the --element-bg (Looks imho better and is the default behavior of other libs)